### PR TITLE
fix: run asset prep before astro check

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "dev": "bun run media:prepare && bun run fonts:prepare && bun run linebreak:build && astro dev",
-    "build": "astro check && bun run media:prepare && bun run fonts:prepare && bun run favicons:check && bun run linebreak:build && astro build --force && pagefind --site dist",
+    "build": "bun run media:prepare && bun run fonts:prepare && bun run favicons:check && bun run linebreak:build && astro check && astro build --force && pagefind --site dist",
     "preview": "astro preview",
     "preview:cloudflare": "bun run build && wrangler dev",
     "deploy:cloudflare": "bun run build && wrangler deploy",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jktrn/enscribe.dev/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->